### PR TITLE
opencode TUI needs file-ioctl

### DIFF
--- a/scode
+++ b/scode
@@ -2325,6 +2325,7 @@ generate_strict_profile() {
 ; a documented limitation of Apple's deprecated sandbox-exec interface.
 (allow sysctl-read)
 (allow mach-lookup)
+(allow file-ioctl)
 
 ; Shared temp storage is denied; a private per-invocation directory is allowed
 ; below after this parent rule.


### PR DESCRIPTION
In strict mode, I get an error:
``` 
scode
scode: strict+opencode: auto-allowing [..]
Error: Unexpected error

setRawMode failed with errno: 1 
```

adding (allow file-ioctl) fixed it for me.

This might fix #1 